### PR TITLE
[PR] Improve logic to determine when to show primary admission menu

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -5,6 +5,55 @@ include_once( 'includes/web-template.php' );
 // Setup the widget used to display the footer area.
 include_once( 'includes/admission-footer-snippets-widget.php' );
 
+/**
+ * Retrieve the ID of the main site for admission.wsu.edu.
+ *
+ * @return int ID of the site.
+ */
+function admission_get_main_site_id() {
+	// The primary domain can be filtered for local development.
+	$home_domain = apply_filters( 'admission_home_domain', 'admission.wsu.edu' );
+
+	$site = get_blog_details( array( 'domain' => $home_domain, 'path' => '/' ) );
+
+	if ( $site ) {
+		return $site->blog_id;
+	}
+
+	return get_current_blog_id();
+}
+
+/**
+ * Determine whether to show the shared, primary navigation from admission.wsu.edu.
+ *
+ * @return bool
+ */
+function admission_show_main_navigation() {
+	$site = get_blog_details();
+
+	// The primary domain can be filtered for local development.
+	$home_domain = apply_filters( 'admission_home_domain', 'admission.wsu.edu' );
+
+	// Site paths that should show the primary navigation. This will include
+	// page paths under these sites.
+	$shared_nav_paths = array(
+		'/',
+		'/for-counselors/',
+		'/for-parents/',
+		'/for-advisors/',
+		'/admitted/',
+	);
+
+	// The shared nav paths can be filtered for local development.
+	$shared_nav_paths = apply_filters( 'admission_shared_nav_paths', $shared_nav_paths );
+
+	if ( $home_domain === $site->domain && in_array( $site->path, $shared_nav_paths ) ) {
+		return true;
+	}
+
+	return false;
+}
+
 add_action( 'after_setup_theme', 'admission_theme_setup' );
 /**
  * Setup functionality used by the theme.

--- a/spine/site-navigation.php
+++ b/spine/site-navigation.php
@@ -1,29 +1,17 @@
 <nav id="spine-sitenav" class="spine-sitenav">
 	<?php
-		
-	$menu = "site";
 
-	if (
-		get_current_blog_id() == 15 ||
-		get_current_blog_id() == 339 ||
-		get_current_blog_id() == 340 ||
-		get_current_blog_id() == 646 ||
-		get_current_blog_id() == 903 ) {
-	
-		if ( defined( 'WSU_LOCAL_CONFIG') && WSU_LOCAL_CONFIG ) {
-			switch_to_blog( 16 );
-			$menu = "network-temp";
-		} elseif ( get_current_blog_id() == 903 ) {
-			switch_to_blog( 267 );
-			$menu = "network";
-		} else {
-			switch_to_blog( 267 );
-			$menu = "network-temp";
-		}
-				
-	}	
-	
-	if ( function_exists( 'bu_navigation_display_primary' ) && $menu !== "network-temp" ) {
+	if ( admission_show_main_navigation() ) {
+		$admission_menu_id = 'network';
+	} else {
+		$admission_menu_id = 'site';
+	}
+
+	if ( 'network' === $admission_menu_id ) {
+		switch_to_blog( admission_get_main_site_id() );
+	}
+
+	if ( function_exists( 'bu_navigation_display_primary' ) ) {
 		$bu_nav_args = array(
 			'post_types'      => array( 'page' ), // post types to display
 			'include_links'   => true, // whether or not to include BU Navigation links with pages
@@ -43,7 +31,7 @@
 	} else {
 		$spine_site_args = array(
 			'theme_location'  => 'site',
-			'menu'            => $menu,
+			'menu'            => $admission_menu_id,
 			'container'       => false,
 			'container_class' => false,
 			'container_id'    => false,
@@ -53,6 +41,10 @@
 			'depth'           => 5,
 		);
 		wp_nav_menu( $spine_site_args );
+	}
+
+	if ( ms_is_switched() ) {
+		restore_current_blog();
 	}
 	?>
 </nav>


### PR DESCRIPTION
We now define a list of 5 site paths that require the primary menu
for admission.wsu.edu. Additional site paths can be added to the
array.

For local development, filter the `admission_home_domain` value
to something like `dev.admission.wsu.edu` and create sites with
similar paths.

If BU Navigation is enabled on the primary site, then it should
also be enabled on any of the other sites. If not, the other sites
will still fall back to the non BU menu from the primary site.